### PR TITLE
Update README for wsj0_2mix_spatialized

### DIFF
--- a/egs2/wsj0_2mix_spatialized/enh1/README.md
+++ b/egs2/wsj0_2mix_spatialized/enh1/README.md
@@ -36,10 +36,36 @@ Model link: https://zenodo.org/record/4512933/files/enh_train_enh_beamformer_no_
 
 |dataset|PESQ|STOI|SAR|SDR|SIR|SI_SNR|
 |---|---|---|---|---|---|---|
-|enhanced_cv_spatialized_reverb_multich|2.89554|0.871864|11.9148|9.50443|16.7254|6.4575|
-|enhanced_tt_spatialized_reverb_multich|2.88883|0.87636|11.8577|9.39594|16.5588|6.38265|
-|enhanced_cv_spatialized_anechoic_multich|3.09721|0.937657|12.6048|11.7628|25.09|9.49375|
-|enhanced_tt_spatialized_anechoic_multich|3.02394|0.943056|12.5872|11.7275|25.0255|9.42349|
-|enhanced_cv_spatialized_anechoic_2ch|3.63867|0.97273|25.386|22.2414|26.0157|20.7877|
-|enhanced_tt_spatialized_anechoic_2ch|3.59756|0.975745|25.3675|22.251|26.017|20.8179|
+|enhanced_cv_spatialized_anechoic_multich_min_8k|3.09721|0.937657|12.6048|11.7628|25.09|9.49375|
+|enhanced_tt_spatialized_anechoic_multich_min_8k|3.02394|0.943056|12.5872|11.7275|25.0255|9.42349|
+|enhanced_cv_spatialized_anechoic_2ch_min_8k|3.63867|0.97273|25.386|22.2414|26.0157|20.7877|
+|enhanced_tt_spatialized_anechoic_2ch_min_8k|3.59756|0.975745|25.3675|22.251|26.017|20.8179|
+
+## Environments
+- date: `Sat Feb  6 16:42:40 CST 2021`
+- python version: `3.6.3 |Anaconda, Inc.| (default, Nov 20 2017, 20:41:42)  [GCC 7.2.0]`
+- espnet version: `espnet 0.9.7`
+- pytorch version: `pytorch 1.6.0`
+- Git hash: `110eca55d633ccba2968ff56ff7bddfd7b3887cb`
+  - Commit date: `Thu Feb 4 01:25:24 2021 +0800`
+
+
+## enh_train_enh_beamformer_no_wpe_raw
+
+config: ./conf/tuning/train_enh_beamformer_no_wpe.yaml
+
+With the following configuration in `run.sh`,
+
+```bash
+train_set=tr_spatialized_reverb_multich_${min_or_max}_${sample_rate}
+valid_set=cv_spatialized_reverb_multich_${min_or_max}_${sample_rate}
+test_sets="tt_spatialized_reverb_multich_${min_or_max}_${sample_rate}"
+```
+
+Model link: https://zenodo.org/record/4513751/files/enh_train_enh_beamformer_no_wpe_raw_valid.loss.best.zip?download=1
+
+|dataset|PESQ|STOI|SAR|SDR|SIR|SI_SNR|
+|---|---|---|---|---|---|---|
+|enhanced_cv_spatialized_reverb_multich_min_8k|2.89554|0.871864|11.9148|9.50443|16.7254|6.4575|
+|enhanced_tt_spatialized_reverb_multich_min_8k|2.88883|0.87636|11.8577|9.39594|16.5588|6.38265|
 

--- a/egs2/wsj0_2mix_spatialized/enh1/README.md
+++ b/egs2/wsj0_2mix_spatialized/enh1/README.md
@@ -32,6 +32,8 @@ config: conf/tuning/train_enh_beamformer_no_wpe.yaml
 
 config: ./conf/tuning/train_enh_beamformer_no_wpe.yaml
 
+Model link: https://zenodo.org/record/4512933/files/enh_train_enh_beamformer_no_wpe_raw_valid.loss.best.zip?download=1
+
 |dataset|PESQ|STOI|SAR|SDR|SIR|SI_SNR|
 |---|---|---|---|---|---|---|
 |enhanced_cv_spatialized_reverb_multich|2.89554|0.871864|11.9148|9.50443|16.7254|6.4575|

--- a/egs2/wsj0_2mix_spatialized/enh1/README.md
+++ b/egs2/wsj0_2mix_spatialized/enh1/README.md
@@ -18,3 +18,26 @@ config: conf/tuning/train_enh_beamformer_no_wpe.yaml
 |---|---|---|---|---|
 |enhanced_cv_spatialized_anechoic_multich|0.965245|24.4831|20.6248|23.7421|
 |enhanced_tt_spatialized_anechoic_multich|0.968908|24.3599|20.4742|23.5676|
+
+## Environments
+- date: `Tue Jan 26 19:31:08 CST 2021`
+- python version: `3.6.3 |Anaconda, Inc.| (default, Nov 20 2017, 20:41:42)  [GCC 7.2.0]`
+- espnet version: `espnet 0.9.7`
+- pytorch version: `pytorch 1.6.0`
+- Git hash: `6534ed0904ba7205c23f387c834bdb40243f4d5a`
+  - Commit date: `Tue Jan 19 22:07:08 2021 +0800`
+
+
+## enh_train_enh_beamformer_no_wpe_raw
+
+config: ./conf/tuning/train_enh_beamformer_no_wpe.yaml
+
+|dataset|PESQ|STOI|SAR|SDR|SIR|SI_SNR|
+|---|---|---|---|---|---|---|
+|enhanced_cv_spatialized_reverb_multich|2.89554|0.871864|11.9148|9.50443|16.7254|6.4575|
+|enhanced_tt_spatialized_reverb_multich|2.88883|0.87636|11.8577|9.39594|16.5588|6.38265|
+|enhanced_cv_spatialized_anechoic_multich|3.09721|0.937657|12.6048|11.7628|25.09|9.49375|
+|enhanced_tt_spatialized_anechoic_multich|3.02394|0.943056|12.5872|11.7275|25.0255|9.42349|
+|enhanced_cv_spatialized_anechoic_2ch|3.63867|0.97273|25.386|22.2414|26.0157|20.7877|
+|enhanced_tt_spatialized_anechoic_2ch|3.59756|0.975745|25.3675|22.251|26.017|20.8179|
+


### PR DESCRIPTION
The training configuration is `egs2/wsj0_2mix_spatialized/enh1/conf/tuning/train_enh_beamformer_no_wpe.yaml`.

Model trained on anechoic data: https://zenodo.org/record/4512933/files/enh_train_enh_beamformer_no_wpe_raw_valid.loss.best.zip?download=1 has been added to RESULT.md

Performance when being tested with all the channels:

|dataset|PESQ|STOI|SAR|SDR|SIR|SI_SNR|
|---|---|---|---|---|---|---|
|enhanced_cv_spatialized_anechoic_multich_min_8k|3.09721|0.937657|12.6048|11.7628|25.09|9.49375|
|enhanced_tt_spatialized_anechoic_multich_min_8k|3.02394|0.943056|12.5872|11.7275|25.0255|9.42349|

Performance when being tested with the 1st and the 2nd channels:

|dataset|PESQ|STOI|SAR|SDR|SIR|SI_SNR|
|---|---|---|---|---|---|---|
|enhanced_cv_spatialized_anechoic_2ch_min_8k|3.63867|0.97273|25.386|22.2414|26.0157|20.7877|
|enhanced_tt_spatialized_anechoic_2ch_min_8k|3.59756|0.975745|25.3675|22.251|26.017|20.8179|


Model trained on data with reverberation: https://zenodo.org/record/4513751/files/enh_train_enh_beamformer_no_wpe_raw_valid.loss.best.zip?download=1 has been added to RESULT.md

Performance:

|dataset|PESQ|STOI|SAR|SDR|SIR|SI_SNR|
|---|---|---|---|---|---|---|
|enhanced_cv_spatialized_reverb_multich_min_8k|2.89554|0.871864|11.9148|9.50443|16.7254|6.4575|
|enhanced_tt_spatialized_reverb_multich_min_8k|2.88883|0.87636|11.8577|9.39594|16.5588|6.38265|
